### PR TITLE
Feat (web): Implement view Registry history page

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,8 +19,8 @@ jobs:
    - uses: actions/setup-node@v3
      with:
       node-version: 18
-      -name: Setup pnpm
-      uses: pnpm/action-setup@v2.4.0
+   - name: Setup pnpm 
+     uses: pnpm/action-setup@v2.4.0
    - name: Install dependencies
      run: pnpm install
    - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,6 +21,8 @@ jobs:
       node-version: 18
    - name: Setup pnpm 
      uses: pnpm/action-setup@v2.4.0
+     with:
+          version: 8
    - name: Install dependencies
      run: pnpm install
    - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
    preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
   steps:
    - name: Wait for Vercel preview deployment to be ready
-     uses: patrickedqvist/wait-for-vercel-preview@1.2.0
+     uses: patrickedqvist/wait-for-vercel-preview@v1.3.1.0
      id: waitForVercelPreviewDeployment
      with:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,7 +30,7 @@ jobs:
    - name: Run Playwright tests
      run: pnpm exec playwright test
      env:
-       PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitForDeploy.outputs.url }}
+       PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
 
    - uses: actions/upload-artifact@v3
      if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,12 +1,10 @@
-name: Playwright Tests
+name: E2E Testing via Playwright
 on:
  push:
   branches: [main, master]
  pull_request:
   branches: [main, master]
 jobs:
-
-
  test:
   timeout-minutes: 60
   runs-on: ubuntu-latest
@@ -21,6 +19,8 @@ jobs:
    - uses: actions/setup-node@v3
      with:
       node-version: 18
+      -name: Setup pnpm
+      uses: pnpm/action-setup@v2.4.0
    - name: Install dependencies
      run: pnpm install
    - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,6 +29,9 @@ jobs:
      run: pnpm exec playwright install --with-deps
    - name: Run Playwright tests
      run: pnpm exec playwright test
+     env:
+       PLAYWRIGHT_TEST_BASE_URL: ${{ steps.waitForDeploy.outputs.url }}
+
    - uses: actions/upload-artifact@v3
      if: always()
      with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
    preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
   steps:
    - name: Wait for Vercel preview deployment to be ready
-     uses: patrickedqvist/wait-for-vercel-preview@1.2.0
+     uses: patrickedqvist/wait-for-vercel-preview@v1.3.1.
      id: waitForVercelPreviewDeployment
      with:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,39 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+ push:
+  branches: [main, master]
+ pull_request:
+  branches: [main, master]
 jobs:
-  test:
-    timeout-minutes: 60
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18
-    - name: Install dependencies
-      run: pnpm install
-    - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
-    - name: Run Playwright tests
-      run: pnpm exec playwright test
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+ test_setup:
+  name: Test setup
+  runs-on: ubuntu-latest
+  outputs:
+   preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
+  steps:
+   - name: Wait for Vercel preview deployment to be ready
+     uses: patrickedqvist/wait-for-vercel-preview@1.2.0
+     id: waitForVercelPreviewDeployment
+     with:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      max_timeout: 600
+ test:
+  timeout-minutes: 60
+  runs-on: ubuntu-latest
+  steps:
+   - uses: actions/checkout@v3
+   - uses: actions/setup-node@v3
+     with:
+      node-version: 18
+   - name: Install dependencies
+     run: pnpm install
+   - name: Install Playwright Browsers
+     run: pnpm exec playwright install --with-deps
+   - name: Run Playwright tests
+     run: pnpm exec playwright test
+   - uses: actions/upload-artifact@v3
+     if: always()
+     with:
+      name: playwright-report
+      path: playwright-report/
+      retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,22 +5,18 @@ on:
  pull_request:
   branches: [main, master]
 jobs:
- test_setup:
-  name: Test setup
+
+
+ test:
+  timeout-minutes: 60
   runs-on: ubuntu-latest
-  outputs:
-   preview_url: ${{ steps.waitForVercelPreviewDeployment.outputs.url }}
   steps:
-   - name: Wait for Vercel preview deployment to be ready
+   name: Wait for Vercel preview deployment to be ready
      uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
      id: waitForVercelPreviewDeployment
      with:
       token: ${{ secrets.GITHUB_TOKEN }}
       max_timeout: 600
- test:
-  timeout-minutes: 60
-  runs-on: ubuntu-latest
-  steps:
    - uses: actions/checkout@v3
    - uses: actions/setup-node@v3
      with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -11,7 +11,7 @@ jobs:
   timeout-minutes: 60
   runs-on: ubuntu-latest
   steps:
-   name: Wait for Vercel preview deployment to be ready
+   - name: Wait for Vercel preview deployment to be ready
      uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
      id: waitForVercelPreviewDeployment
      with:

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 - [ ✅ ] Implement View projects page
 - [ ✅ ] Implement View project page
 - [ 🚧 ] Implement Registry history page
-- [ 🚧 ] Implement Create Registry feature
+- [ ✅ ] Implement Create Registry feature
 - [ 🚧 ] Implement Delete Registry feature
 
 ## Back

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,6 @@ export default defineNuxtConfig({
 
 	app: {
 		head: {
-			htmlAttrs: { class: 'dark' },
 			bodyAttrs: { class: 'bg-background text-primary' },
 		},
 		pageTransition: { name: 'page', mode: 'out-in' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,7 +1,12 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
 	devtools: { enabled: true },
-	modules: ['@nuxtjs/google-fonts', '@sidebase/nuxt-auth', 'nuxt-icon'],
+	modules: [
+		'@nuxtjs/google-fonts',
+		'@sidebase/nuxt-auth',
+		'nuxt-icon',
+		'@vueuse/nuxt',
+	],
 	googleFonts: {
 		download: true,
 		families: { Inter: true },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nuxt-app",
   "private": true,
   "scripts": {
-    "build": "nuxt build",
+    "build": "prisma generate && nuxt build",
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@sidebase/nuxt-auth": "0.5.0",
     "@types/node": "^18.17.1",
     "@types/pg": "^8.10.2",
+    "@vueuse/core": "^10.3.0",
     "@vueuse/nuxt": "^10.3.0",
     "dotenv": "^16.3.1",
     "nuxt": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@sidebase/nuxt-auth": "0.5.0",
     "@types/node": "^18.17.1",
     "@types/pg": "^8.10.2",
+    "@vueuse/nuxt": "^10.3.0",
     "dotenv": "^16.3.1",
     "nuxt": "^3.6.5",
     "nuxt-icon": "^0.4.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
 
 		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
 		trace: 'on-first-retry',
-		baseURL: process.env.NUXT_BASE_URL,
+		baseURL: process.env.PLAYWRIGHT_TEST_BASE_URL ?? 'http://localhost:3000',
 	},
 
 	/* Configure projects for major browsers */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ devDependencies:
   '@types/pg':
     specifier: ^8.10.2
     version: 8.10.2
+  '@vueuse/core':
+    specifier: ^10.3.0
+    version: 10.3.0(vue@3.3.4)
   '@vueuse/nuxt':
     specifier: ^10.3.0
     version: 10.3.0(nuxt@3.6.5)(vue@3.3.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ dependencies:
 devDependencies:
   '@nuxt/devtools':
     specifier: latest
-    version: 0.7.4(nuxt@3.6.5)(vite@4.4.8)
+    version: 0.8.0(nuxt@3.6.5)(vite@4.4.8)
   '@nuxtjs/google-fonts':
     specifier: ^3.0.2
     version: 3.0.2
@@ -58,6 +58,9 @@ devDependencies:
   '@types/pg':
     specifier: ^8.10.2
     version: 8.10.2
+  '@vueuse/nuxt':
+    specifier: ^10.3.0
+    version: 10.3.0(nuxt@3.6.5)(vue@3.3.4)
   dotenv:
     specifier: ^16.3.1
     version: 16.3.1
@@ -1194,8 +1197,8 @@ packages:
     resolution: {integrity: sha512-GBzP8zOc7CGWyFQS6dv1lQz8VVpz5C2yRszbXufwG/9zhStTIH50EtD87NmWbTMwXDvZLNg8GIpb1UFdH93JCA==}
     dev: true
 
-  /@nuxt/devtools-kit@0.7.4(nuxt@3.6.5)(vite@4.4.8):
-    resolution: {integrity: sha512-+CKSSqalyW3elK364FamcHtXm6F03Iarfs9ftBiWmj3CdCTuv9aGpJFi0FKzXKzq/xlCtbWvIrqcaf2Iy//6NQ==}
+  /@nuxt/devtools-kit@0.8.0(nuxt@3.6.5)(vite@4.4.8):
+    resolution: {integrity: sha512-zHwotLFwmYPFDg0JHyInn0L3i2gZK24JYDfgOzqBuvCD/Q3ytQVyAMrX2Mp4iIrHjwToZBJ0dlyV+UYXCiWwSg==}
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
@@ -1210,8 +1213,8 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/devtools-wizard@0.7.4:
-    resolution: {integrity: sha512-Ga+OgxTEZu0AnOmak5eMPrFThvLdoFVB5kEyyCrnBNdkTvX5Dtr8FvVAL+6jV0ALmqhWSXp99op2+QwHg7kgDg==}
+  /@nuxt/devtools-wizard@0.8.0:
+    resolution: {integrity: sha512-nxYAB4TQgeaoYY3xBEzrYVpXzXUAwoeCui0vqu1oTeeuKnl62uXFGsY4vXMHQtnibvbQVZzNFVFoXggKM3MBGw==}
     hasBin: true
     dependencies:
       consola: 3.2.3
@@ -1227,15 +1230,15 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /@nuxt/devtools@0.7.4(nuxt@3.6.5)(vite@4.4.8):
-    resolution: {integrity: sha512-uaKvVIYWuJ5L1NasXYiZfOh3w2HkHwaMyyVCceabVsOh27PBIeV7rzF5zyMrkyO3vivmWUuXcoZo3M0JO41sqg==}
+  /@nuxt/devtools@0.8.0(nuxt@3.6.5)(vite@4.4.8):
+    resolution: {integrity: sha512-w48eqZ52NLVB8C0Q1E/eY0xsokMr9diOaxUptO08UYNhyj+MKKBrhIBTePYO7GlxabXOaHM62zi+iN8AT1qXoA==}
     hasBin: true
     peerDependencies:
       nuxt: ^3.6.5
       vite: '*'
     dependencies:
-      '@nuxt/devtools-kit': 0.7.4(nuxt@3.6.5)(vite@4.4.8)
-      '@nuxt/devtools-wizard': 0.7.4
+      '@nuxt/devtools-kit': 0.8.0(nuxt@3.6.5)(vite@4.4.8)
+      '@nuxt/devtools-wizard': 0.8.0
       '@nuxt/kit': 3.6.5
       birpc: 0.2.12
       boxen: 7.1.1
@@ -1266,7 +1269,7 @@ packages:
       unimport: 3.1.3(rollup@3.27.1)
       vite: 4.4.8(@types/node@18.17.1)
       vite-plugin-inspect: 0.7.35(@nuxt/kit@3.6.5)(vite@4.4.8)
-      vite-plugin-vue-inspector: 3.5.0(vite@4.4.8)
+      vite-plugin-vue-inspector: 3.6.0(vite@4.4.8)
       wait-on: 7.0.1
       which: 3.0.1
       ws: 8.13.0
@@ -1809,6 +1812,10 @@ packages:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
     dev: true
 
+  /@types/web-bluetooth@0.0.17:
+    resolution: {integrity: sha512-4p9vcSmxAayx72yn70joFoL44c9MO/0+iVEBIQXe3v2h2SiAsEIo/G5v6ObFWvNKRFjbrVadNf9LqEEZeQPzdA==}
+    dev: true
+
   /@unhead/dom@1.2.2:
     resolution: {integrity: sha512-ohganmg4i1Dd4wwQ2A9oLWEkJNpJRoERJNmFgzmScw9Vi3zMqoS4gPIofT20zUR5rhyyAsFojuDPojJ5vKcmqw==}
     dependencies:
@@ -2015,6 +2022,49 @@ packages:
 
   /@vue/shared@3.3.4:
     resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
+
+  /@vueuse/core@10.3.0(vue@3.3.4):
+    resolution: {integrity: sha512-BEM5yxcFKb5btFjTSAFjTu5jmwoW66fyV9uJIP4wUXXU8aR5Hl44gndaaXp7dC5HSObmgbnR2RN+Un1p68Mf5Q==}
+    dependencies:
+      '@types/web-bluetooth': 0.0.17
+      '@vueuse/metadata': 10.3.0
+      '@vueuse/shared': 10.3.0(vue@3.3.4)
+      vue-demi: 0.14.5(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
+
+  /@vueuse/metadata@10.3.0:
+    resolution: {integrity: sha512-Ema3YhNOa4swDsV0V7CEY5JXvK19JI/o1szFO1iWxdFg3vhdFtCtSTP26PCvbUpnUtNHBY2wx5y3WDXND5Pvnw==}
+    dev: true
+
+  /@vueuse/nuxt@10.3.0(nuxt@3.6.5)(vue@3.3.4):
+    resolution: {integrity: sha512-Dmkm9H5Ubq279+FHhlJtlFP99wKrn2apuo4hk/0GbEi/6+zif7MJRtAjDBBV4VjmY6XV3kO8dQR8940FStbxsA==}
+    peerDependencies:
+      nuxt: ^3.0.0
+    dependencies:
+      '@nuxt/kit': 3.6.5
+      '@vueuse/core': 10.3.0(vue@3.3.4)
+      '@vueuse/metadata': 10.3.0
+      local-pkg: 0.4.3
+      nuxt: 3.6.5(@types/node@18.17.1)
+      vue-demi: 0.14.5(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - rollup
+      - supports-color
+      - vue
+    dev: true
+
+  /@vueuse/shared@10.3.0(vue@3.3.4):
+    resolution: {integrity: sha512-kGqCTEuFPMK4+fNWy6dUOiYmxGcUbtznMwBZLC1PubidF4VZY05B+Oht7Jh7/6x4VOWGpvu3R37WHi81cKpiqg==}
+    dependencies:
+      vue-demi: 0.14.5(vue@3.3.4)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+    dev: true
 
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
@@ -8204,8 +8254,8 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-vue-inspector@3.5.0(vite@4.4.8):
-    resolution: {integrity: sha512-dDoxEi5VWkfsKflVUYxElC3XD/MOn8s/6mjCqWRDlFIQ+OsY0cW5PNTbqxGllbBBCr5SDnDmPWFS1vMJxrLVEw==}
+  /vite-plugin-vue-inspector@3.6.0(vite@4.4.8):
+    resolution: {integrity: sha512-Fi+9JaMx/reuic+MWbrdw8g5TwZM5a/BmdBT8OKKZi3rK4Qw3wND9smT+Ld+Daitbgly17uvuCiull2KV/hEBQ==}
     peerDependencies:
       vite: ^3.0.0-0 || ^4.0.0-0
     dependencies:
@@ -8351,7 +8401,6 @@ packages:
         optional: true
     dependencies:
       vue: 3.3.4
-    dev: false
 
   /vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}

--- a/src/app.vue
+++ b/src/app.vue
@@ -15,4 +15,36 @@
 		opacity: 0;
 		filter: blur(1rem);
 	}
+	.dark {
+		--background: 224 71% 4%;
+		--foreground: 213 31% 91%;
+
+		--muted: 223 47% 11%;
+		--muted-foreground: 215.4 16.3% 56.9%;
+
+		--accent: 216 34% 17%;
+		--accent-foreground: 210 40% 98%;
+
+		--popover: 224 71% 4%;
+		--popover-foreground: 215 20.2% 65.1%;
+
+		--border: 216 34% 17%;
+		--input: 216 34% 17%;
+
+		--card: 224 71% 4%;
+		--card-foreground: 213 31% 91%;
+
+		--primary: 210 40% 98%;
+		--primary-foreground: 222.2 47.4% 1.2%;
+
+		--secondary: 222.2 47.4% 11.2%;
+		--secondary-foreground: 210 40% 98%;
+
+		--destructive: 0 63% 31%;
+		--destructive-foreground: 210 40% 98%;
+
+		--ring: 216 34% 17%;
+
+		--radius: 0.5rem;
+	}
 </style>

--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -1,81 +1,48 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
- 
+
 @layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 47.4% 11.2%;
- 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
- 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 47.4% 11.2%;
- 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
- 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 47.4% 11.2%;
- 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
- 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
- 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
- 
-    --destructive: 0 100% 50%;
-    --destructive-foreground: 210 40% 98%;
- 
-    --ring: 215 20.2% 65.1%;
- 
-    --radius: 0.5rem;
-  }
- 
-  .dark {
-    --background: 224 71% 4%;
-    --foreground: 213 31% 91%;
- 
-    --muted: 223 47% 11%;
-    --muted-foreground: 215.4 16.3% 56.9%;
- 
-    --accent: 216 34% 17%;
-    --accent-foreground: 210 40% 98%;
- 
-    --popover: 224 71% 4%;
-    --popover-foreground: 215 20.2% 65.1%;
- 
-    --border: 216 34% 17%;
-    --input: 216 34% 17%;
- 
-    --card: 224 71% 4%;
-    --card-foreground: 213 31% 91%;
- 
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 1.2%;
- 
-    --secondary: 222.2 47.4% 11.2%;
-    --secondary-foreground: 210 40% 98%;
- 
-    --destructive: 0 63% 31%;
-    --destructive-foreground: 210 40% 98%;
- 
-    --ring: 216 34% 17%;
- 
-    --radius: 0.5rem;
-  }
+	:root {
+		--background: 0 0% 100%;
+		--foreground: 222.2 47.4% 11.2%;
+
+		--muted: 210 40% 96.1%;
+		--muted-foreground: 215.4 16.3% 46.9%;
+
+		--popover: 0 0% 100%;
+		--popover-foreground: 222.2 47.4% 11.2%;
+
+		--border: 214.3 31.8% 91.4%;
+		--input: 214.3 31.8% 91.4%;
+
+		--card: 0 0% 100%;
+		--card-foreground: 222.2 47.4% 11.2%;
+
+		--primary: 222.2 47.4% 11.2%;
+		--primary-foreground: 210 40% 98%;
+
+		--secondary: 210 40% 96.1%;
+		--secondary-foreground: 222.2 47.4% 11.2%;
+
+		--accent: 210 40% 96.1%;
+		--accent-foreground: 222.2 47.4% 11.2%;
+
+		--destructive: 0 100% 50%;
+		--destructive-foreground: 210 40% 98%;
+
+		--ring: 215 20.2% 65.1%;
+
+		--radius: 0.5rem;
+	}
 }
- 
+
 @layer base {
-  * {
-    @apply border-border;
-  }
-  body {
-    @apply bg-background text-foreground;
-    font-feature-settings: "rlig" 1, "calt" 1;
-  }
+	* {
+		@apply border-border;
+	}
+	body {
+		@apply bg-background text-foreground;
+		font-feature-settings: 'rlig' 1, 'calt' 1;
+	}
 }

--- a/src/components/project/item.server.vue
+++ b/src/components/project/item.server.vue
@@ -10,7 +10,7 @@
 
 <template>
 	<article
-		class="flex flex-col justify-between w-full h-full p-3 space-y-1 rounded-md shadow-md min-h-[9rem]"
+		class="flex flex-col justify-between w-full h-full p-3 space-y-1 rounded-md border-2 border-primary/5 min-h-[9rem]"
 	>
 		<aside class="flex flex-col mb-3 space-y-2">
 			<h3 className="scroll-m-20 text-2xl font-semibold tracking-tight">

--- a/src/components/project/item.server.vue
+++ b/src/components/project/item.server.vue
@@ -23,7 +23,7 @@
 		>
 			<NuxtLink
 				:to="projectPath"
-				class="w-full p-2 text-center text-white rounded-sm hover:opacity-90 xl:w-1/6 place-self-end bg-secondary-foreground"
+				class="w-full p-2 text-center rounded-sm text-background hover:opacity-90 xl:w-1/6 place-self-end bg-secondary-foreground"
 				>View Project</NuxtLink
 			>
 		</aside>

--- a/src/components/registry/empty.server.vue
+++ b/src/components/registry/empty.server.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+	const props = defineProps<{ projectId: string }>()
+	const projectPath = `/home/project/${props.projectId}`
+</script>
+<template>
+	<section
+		class="flex flex-col items-center justify-center h-screen space-y-1 text-center"
+	>
+		<UiParagraph
+			>It seems you have no registry defined yet. You can define your registries on
+			your project panel.</UiParagraph
+		>
+
+		<NuxtLink :to="projectPath" class="underline"
+			>Click over here to view your panel.</NuxtLink
+		>
+	</section>
+</template>

--- a/src/components/registry/item.server.vue
+++ b/src/components/registry/item.server.vue
@@ -13,9 +13,9 @@
 </script>
 <template>
 	<article
-		class="flex flex-col justify-center w-full h-full p-3 space-y-1 rounded-md shadow-md min-h-[11rem] border-2 border-primary/5"
+		class="flex flex-col justify-between h-full p-3 space-y-1 rounded-md shadow-md min-h-[8rem] border-2 border-primary/5"
 	>
-		<span class="flex flex-row items-center space-x-1">
+		<span class="flex flex-row items-center pt-3 space-x-1 font-medium">
 			<time :datetime="registryDate.toString()">{{ registryTime }}</time>
 			<p>({{ registry.id }})</p>
 		</span>

--- a/src/components/registry/item.server.vue
+++ b/src/components/registry/item.server.vue
@@ -13,14 +13,14 @@
 </script>
 <template>
 	<article
-		class="flex flex-col justify-center w-full h-full p-3 space-y-1 rounded-md shadow-md min-h-[9rem] border-2 border-primary/5"
+		class="flex flex-col justify-center w-full h-full p-3 space-y-1 rounded-md shadow-md min-h-[11rem] border-2 border-primary/5"
 	>
 		<span class="flex flex-row items-center space-x-1">
 			<time :datetime="registryDate.toString()">{{ registryTime }}</time>
 			<p>({{ registry.id }})</p>
 		</span>
 		<NuxtLink
-			class="w-full p-2 text-center rounded-sm text-background hover:opacity-90 xl:w-1/6 place-self-end bg-secondary-foreground"
+			class="self-end w-full p-2 text-center rounded-sm text-background hover:opacity-90 xl:w-1/6 place-self-end bg-secondary-foreground"
 			:to="registryHref"
 			>View registry</NuxtLink
 		>

--- a/src/components/registry/item.server.vue
+++ b/src/components/registry/item.server.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+	import { Registry } from '@prisma/client'
+	import { retrieveDateOnISOFormat } from '@/utils/parse-date'
+	type Props = {
+		registry: Registry
+		projectId: string
+	}
+	const props = defineProps<Props>()
+	const registryDate = new Date(props.registry.createdAt)
+	const registryTime = retrieveDateOnISOFormat(registryDate)
+
+	const registryHref = `/home/project/${props.projectId}/registry/${props.registry.id}`
+</script>
+<template>
+	<article
+		class="flex flex-col justify-center w-full h-full p-3 space-y-1 rounded-md shadow-md min-h-[9rem] border-2 border-primary/5"
+	>
+		<span class="flex flex-row items-center space-x-1">
+			<time :datetime="registryDate.toString()">{{ registryTime }}</time>
+			<p>({{ registry.id }})</p>
+		</span>
+		<NuxtLink
+			class="w-full p-2 text-center rounded-sm text-background hover:opacity-90 xl:w-1/6 place-self-end bg-secondary-foreground"
+			:to="registryHref"
+			>View registry</NuxtLink
+		>
+	</article>
+</template>

--- a/src/components/registry/list.server.vue
+++ b/src/components/registry/list.server.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+	import { Registry } from '@prisma/client'
+
+	type Props = {
+		registries: Registry[]
+		projectId:string;
+	}
+	defineProps<Props>()
+</script>
+<template>
+	<section class="grid w-full grid-rows-3 mx-auto mt-10 gap-9">
+		<RegistryItem
+			v-for="registry in registries"
+			:key="registry.id"
+			:registry="registry"
+			:project-id="projectId"
+		/>
+	</section>
+</template>

--- a/src/components/registry/result-icon.vue
+++ b/src/components/registry/result-icon.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+	defineProps<{ status: 'success' | 'error' | 'warning' }>()
+</script>
+<template>
+	<template v-if="status === 'success'">
+		<Icon
+			name="carbon:checkmark-filled"
+			class="self-center w-10 h-10 text-emerald-500"
+		/>
+	</template>
+	<template v-else-if="status === 'warning'">
+		<Icon
+			name="carbon:warning-filled"
+			class="self-center w-10 h-10 text-amber-500"
+		/>
+	</template>
+		<template v-else>
+		<Icon
+			name="carbon:error-filled"
+			class="self-center w-10 h-10 text-red-500"
+		/>
+	</template>
+</template>

--- a/src/components/registry/result.vue
+++ b/src/components/registry/result.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+	type Props = {
+		metric: string
+		label: string
+	}
+	const props = defineProps<Props>()
+	const resultStatus = computed(() =>
+		Number(props.metric.replace('s', '')) < 2
+			? 'success'
+			: Number(props.metric.replace('s', '')) < 3
+			? 'warning'
+			: 'error'
+	)
+	const metricStyles = ` text-sm text-center ${
+		resultStatus.value === 'success'
+			? 'text-emerald-500'
+			: resultStatus.value === 'warning'
+			? 'text-amber-500'
+			: 'text-red-500'
+	}`
+</script>
+<template>
+	<aside class="flex flex-col justify-center h-48 space-y-1">
+		<RegistryResultIcon :status="resultStatus" />
+		<UiParagraph class="text-center">{{ label }}</UiParagraph>
+		<p :class="metricStyles">{{ metric }}</p>
+	</aside>
+</template>

--- a/src/components/registry/result.vue
+++ b/src/components/registry/result.vue
@@ -4,13 +4,7 @@
 		label: string
 	}
 	const props = defineProps<Props>()
-	const resultStatus = computed(() =>
-		Number(props.metric.replace('s', '')) < 2
-			? 'success'
-			: Number(props.metric.replace('s', '')) < 3
-			? 'warning'
-			: 'error'
-	)
+	const { resultStatus } = useMetricStatus(props.metric)
 	const metricStyles = ` text-sm text-center ${
 		resultStatus.value === 'success'
 			? 'text-emerald-500'

--- a/src/components/ui/theme-switcher.vue
+++ b/src/components/ui/theme-switcher.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+	const dark = useDark()
+	const toggleDarkMode = () => (dark.value = !dark.value)
+</script>
+<template>
+	<button
+		class="p-2 duration-100 border-2 rounded-md hover:bg-primary/5"
+		@click="toggleDarkMode"
+	>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="32"
+			height="32"
+			viewBox="0 0 32 32"
+			class="hidden w-5 h-5 ease-in-out dark:block"
+		>
+			<path
+				fill="currentColor"
+				d="M13.502 5.414a15.075 15.075 0 0 0 11.594 18.194a11.113 11.113 0 0 1-7.975 3.39c-.138 0-.278.005-.418 0a11.094 11.094 0 0 1-3.2-21.584M14.98 3a1.002 1.002 0 0 0-.175.016a13.096 13.096 0 0 0 1.825 25.981c.164.006.328 0 .49 0a13.072 13.072 0 0 0 10.703-5.555a1.01 1.01 0 0 0-.783-1.565A13.08 13.08 0 0 1 15.89 4.38A1.015 1.015 0 0 0 14.98 3Z"
+			></path>
+		</svg>
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			width="32"
+			height="32"
+			viewBox="0 0 32 32"
+			class="block w-5 h-5 ease-in-out dark:hidden"
+		>
+			<path
+				fill="currentColor"
+				d="M16 12.005a4 4 0 1 1-4 4a4.005 4.005 0 0 1 4-4m0-2a6 6 0 1 0 6 6a6 6 0 0 0-6-6ZM5.394 6.813L6.81 5.399l3.505 3.506L8.9 10.319zM2 15.005h5v2H2zm3.394 10.193L8.9 21.692l1.414 1.414l-3.505 3.506zM15 25.005h2v5h-2zm6.687-1.9l1.414-1.414l3.506 3.506l-1.414 1.414zm3.313-8.1h5v2h-5zm-3.313-6.101l3.506-3.506l1.414 1.414l-3.506 3.506zM15 2.005h2v5h-2z"
+			></path>
+		</svg>
+	</button>
+</template>

--- a/src/composables/metrics.ts
+++ b/src/composables/metrics.ts
@@ -1,0 +1,33 @@
+export const useMetricStatus = (metric: string) => {
+	const isMiliseconds = metric.trim().includes('ms')
+	const isSeconds = metric.trim().includes('s')
+
+	const resultStatus = computed(() => {
+		if (isMiliseconds) {
+			const parsedMetric = metric.trim().replace('ms', '')
+			if (Number(parsedMetric) <= 100) {
+				return 'success'
+			}
+			if (Number(parsedMetric) < 300) {
+				return 'warning'
+			}
+			return 'error'
+		} else if (isSeconds) {
+			const parsedMetric = metric.trim().replace('s', '')
+
+			if (Math.round(Number(parsedMetric)) >= 1) {
+				return 'success'
+			}
+			if (Math.round(Number(parsedMetric)) >= 5) {
+				return 'warning'
+			}
+			return 'error'
+		} else {
+			if (Number(metric) >= 0) {
+				return 'success'
+			}
+			return 'error'
+		}
+	})
+	return { resultStatus }
+}

--- a/src/composables/registry.ts
+++ b/src/composables/registry.ts
@@ -73,7 +73,7 @@ export const useGetRegistryById = async (registryId: string) => {
 			headers: { 'content-type': 'application/json' },
 		})
 
-		const resp = (await data.json()) as { existingRegistries: Registry }
-		return resp.existingRegistries
+		const resp = (await data.json()) as { existingRegistry: Registry }
+		return resp.existingRegistry
 	})
 }

--- a/src/composables/registry.ts
+++ b/src/composables/registry.ts
@@ -1,6 +1,7 @@
 import { LighthouseAPIResult } from '@/types'
 import { RegistryOutput } from '@/utils/valibot'
 import { Registry } from '@prisma/client'
+
 export const useCreateRegistry = (projectId: string) => {
 	const config = useRuntimeConfig()
 	const API_URL = config.public.API_URL
@@ -47,4 +48,15 @@ export const useCreateRegistry = (projectId: string) => {
 		}
 	}
 	return { create, isLoading }
+}
+
+export const useGetRegistriesByProjectId = async (projectId: string) => {
+	const config = useRuntimeConfig()
+	const API_URL = config.public.API_URL
+	const data = await fetch(`${API_URL}/project/${projectId}/registry`, {
+		method: 'GET',
+		headers: { 'content-type': 'application/json' },
+	})
+	const resp = (await data.json()) as { existingRegistries: Registry[] }
+	return resp.existingRegistries
 }

--- a/src/composables/registry.ts
+++ b/src/composables/registry.ts
@@ -14,7 +14,7 @@ export const useCreateRegistry = (projectId: string) => {
 		try {
 			isLoading.value = true
 			const pageSpeedInsightRes = await fetch(
-				`${PAGESPEED_API_URL}?url=${siteUrl}&key=${PAGESPEED_API_KEY}`
+				`${PAGESPEED_API_URL}?url=${siteUrl}&key=${PAGESPEED_API_KEY}&strategy=mobile`
 			)
 			const pageSpeedData: LighthouseAPIResult = await pageSpeedInsightRes.json()
 

--- a/src/pages/home.vue
+++ b/src/pages/home.vue
@@ -14,7 +14,14 @@
 			>
 				<NuxtLink to="/home/project" v-if="isRouteOnProjectPath">Projects</NuxtLink>
 				<NuxtLink to="/home" v-else>Home</NuxtLink>
-				<HomeMenubar />
+				<ul class="flex flex-row items-center space-x-4">
+					<li>
+						<ClientOnly>
+							<UiThemeSwitcher />
+						</ClientOnly>
+					</li>
+					<li><HomeMenubar /></li>
+				</ul>
 			</nav>
 		</header>
 

--- a/src/pages/home.vue
+++ b/src/pages/home.vue
@@ -8,7 +8,7 @@
 
 <template>
 	<div>
-		<header class="p-5 ">
+		<header class="p-5 border-b-2">
 			<nav
 				class="container flex flex-row items-center justify-between max-w-4xl mx-auto"
 			>

--- a/src/pages/home.vue
+++ b/src/pages/home.vue
@@ -8,7 +8,7 @@
 
 <template>
 	<div>
-		<header class="p-5 border-b-2">
+		<header class="p-5 ">
 			<nav
 				class="container flex flex-row items-center justify-between max-w-4xl mx-auto"
 			>

--- a/src/pages/home/index.vue
+++ b/src/pages/home/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 
-	useSeoMeta({ title: 'Ashou - Home' })
+	useSeoMeta({ title: 'Webmetrics - Home' })
 	const { data, pending } = await useGetProjects()
 </script>
 

--- a/src/pages/home/project.vue
+++ b/src/pages/home/project.vue
@@ -4,9 +4,11 @@
 </script>
 
 <template>
-	<div class="h-full ">
+	<div class="h-full">
 		<section class="hidden h-full xl:flex lg:flex md:flex xl:flex-row">
-			<article class="flex flex-col justify-between h-full min-h-screen border-r-2 w-96">
+			<article
+				class="flex flex-col justify-between h-full min-h-screen border-r-2 w-96"
+			>
 				<div class="flex flex-col justify-center w-full h-full space-y-1">
 					<h1 class="mx-4 mt-2 text-lg font-bold text-center">Recent projects</h1>
 					<ProjectSidebarList
@@ -33,14 +35,6 @@
 						<Icon name="material-symbols:assignment-add" class="w-6 h-6" />
 						<span>New project</span></NuxtLink
 					>
-					<NuxtLink
-						to="/home/project/historial"
-						class="flex flex-row items-center justify-start w-full p-5 space-x-5 text-base font-medium duration-100 ease-in-out rounded-md hover:bg-primary/10"
-						active-class="text-white bg-primary"
-					>
-						<Icon name="material-symbols:list-alt" class="w-6 h-6" />
-						<span>View historial</span>
-					</NuxtLink>
 
 					<button
 						class="inline-flex items-center justify-start p-5 space-x-5 text-base font-medium transition-colors rounded-md ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90"
@@ -52,7 +46,9 @@
 				</div>
 			</article>
 
-			<article class="w-full h-full min-h-screen place-items-center bg-secondary dark:bg-secondary/10">
+			<article
+				class="w-full h-full min-h-screen place-items-center bg-secondary dark:bg-secondary/10"
+			>
 				<div
 					class="container grid w-full h-full max-w-6xl mx-auto mt-4 rounded-md shadow-sm place-items-center bg-background"
 				>

--- a/src/pages/home/project.vue
+++ b/src/pages/home/project.vue
@@ -4,9 +4,9 @@
 </script>
 
 <template>
-	<div class="h-full min-h-screen">
+	<div class="h-full ">
 		<section class="hidden h-full xl:flex lg:flex md:flex xl:flex-row">
-			<article class="flex flex-col justify-between h-full min-h-screen w-96">
+			<article class="flex flex-col justify-between h-full min-h-screen border-r-2 w-96">
 				<div class="flex flex-col justify-center w-full h-full space-y-1">
 					<h1 class="mx-4 mt-2 text-lg font-bold text-center">Recent projects</h1>
 					<ProjectSidebarList
@@ -52,8 +52,12 @@
 				</div>
 			</article>
 
-			<article class="grid items-center w-full place-items-center bg-secondary">
-				<NuxtPage />
+			<article class="w-full h-full min-h-screen place-items-center bg-secondary dark:bg-secondary/10">
+				<div
+					class="container grid w-full h-full max-w-6xl mx-auto mt-4 rounded-md shadow-sm place-items-center bg-background"
+				>
+					<NuxtPage />
+				</div>
 			</article>
 		</section>
 		<section class="relative h-screen xl:h-full xl:hidden lg:hidden">

--- a/src/pages/home/project/[id]/history/index.vue
+++ b/src/pages/home/project/[id]/history/index.vue
@@ -1,19 +1,34 @@
 <script setup lang="ts">
 	const route = useRoute('home-project-id-history')
+	const router = useRouter()
 	const id = route.params.id
+
+	const navigateBackward = () => router.go(-1)
 	const { data } = await useGetRegistriesByProjectId(id)
-	console.log(data.value)
 </script>
 <template>
-	<main
-		class="container w-full h-full max-w-5xl mx-auto mt-3 rounded-md shadow-sm bg-background"
-	>
-		<section v-for="registry in data">
-			<time :datetime="new Date(registry.createdAt).toString()">{{
-				new Date(registry.createdAt).toString()
-			}}</time>
-			<p>{{ registry.id }}</p>
-		</section>
-		<div>{{ JSON.stringify(data) }}</div>
+	<main class="w-full h-full mt-3">
+		<aside class="flex flex-row items-center p-5 mb-3 space-x-1">
+			<Icon
+				name="carbon:arrow-left"
+				class="duration-100 ease-in-out w-7 h-7 hover:cursor-pointer hover:opacity-70"
+				@click="navigateBackward"
+			/>
+		</aside>
+		<div
+			class="container grid w-full h-full max-w-4xl mx-auto space-y-1 place-items-center"
+		>
+			<h2
+				class="pb-2 mb-4 text-3xl font-semibold tracking-tight text-center transition-colors border-b scroll-m-20 first:mt-0"
+			>
+				Registry list
+			</h2>
+			<RegistryList
+				v-if="data && data.length"
+				:registries="data"
+				:project-id="id"
+			/>
+			<RegistryEmpty v-else :project-id="id" />
+		</div>
 	</main>
 </template>

--- a/src/pages/home/project/[id]/history/index.vue
+++ b/src/pages/home/project/[id]/history/index.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+	const route = useRoute('home-project-id-history')
+	const id = route.params.id
+	const { data } = await useGetRegistriesByProjectId(id)
+	console.log(data.value)
+</script>
+<template>
+	<main
+		class="container w-full h-full max-w-5xl mx-auto mt-3 rounded-md shadow-sm bg-background"
+	>
+		<section v-for="registry in data">
+			<time :datetime="new Date(registry.createdAt).toString()">{{
+				new Date(registry.createdAt).toString()
+			}}</time>
+			<p>{{ registry.id }}</p>
+		</section>
+		<div>{{ JSON.stringify(data) }}</div>
+	</main>
+</template>

--- a/src/pages/home/project/[id]/history/index.vue
+++ b/src/pages/home/project/[id]/history/index.vue
@@ -5,6 +5,7 @@
 
 	const navigateBackward = () => router.go(-1)
 	const { data } = await useGetRegistriesByProjectId(id)
+	useSeoMeta({ title: 'Webmetrics - View project history' })
 </script>
 <template>
 	<main class="w-full h-full mt-3">

--- a/src/pages/home/project/[id]/index.vue
+++ b/src/pages/home/project/[id]/index.vue
@@ -9,12 +9,12 @@
 		}
 	})
 	useSeoMeta({
-		title: `Ashou | Proyecto actual: ${data?.value?.existingProject?.name}`,
+		title: `Webmetrics | Actual project: ${data?.value?.existingProject?.name}`,
 	})
 </script>
 <template>
 	<main
-		class="flex flex-col justify-center w-full h-full max-w-2xl space-y-3 sm:min-h-screen"
+		class="flex flex-col justify-center w-full h-full max-w-4xl space-y-3 sm:min-h-screen"
 	>
 		<h2
 			class="pb-2 mb-4 text-3xl font-semibold tracking-tight text-center transition-colors border-b scroll-m-20 first:mt-0"

--- a/src/pages/home/project/[id]/index.vue
+++ b/src/pages/home/project/[id]/index.vue
@@ -14,18 +14,16 @@
 </script>
 <template>
 	<main
-		class="flex flex-col justify-center w-full h-full max-w-2xl space-y-1 sm:min-h-screen"
+		class="flex flex-col justify-center w-full h-full max-w-2xl space-y-3 sm:min-h-screen"
 	>
 		<h2
-			class="pb-2 text-3xl font-semibold tracking-tight text-center transition-colors border-b scroll-m-20 first:mt-0"
+			class="pb-2 mb-4 text-3xl font-semibold tracking-tight text-center transition-colors border-b scroll-m-20 first:mt-0"
 		>
 			{{ data?.existingProject?.name }}
 		</h2>
-		<NuxtLink class="p-3 hover:underline" :to="`/home/project/${id}/compare`"
-			>Compare registries</NuxtLink
-		>
+
 		<NuxtLink
-			class="p-3 rounded-md hover:underline"
+			class="p-3 text-center underline rounded-md"
 			:to="`/home/project/${id}/history`"
 			>View registry history</NuxtLink
 		>

--- a/src/pages/home/project/[id]/registry/[registryId].vue
+++ b/src/pages/home/project/[id]/registry/[registryId].vue
@@ -5,7 +5,7 @@
 	const navigateBackward = () => router.go(-1)
 
 	const { data: registry } = await useGetRegistryById(registryId)
-	useSeoMeta({ title: 'Ashou - View registry results' })
+	useSeoMeta({ title: 'Webmetrics - View registry results' })
 </script>
 <template>
 	<main

--- a/src/pages/home/project/[id]/registry/[registryId].vue
+++ b/src/pages/home/project/[id]/registry/[registryId].vue
@@ -1,11 +1,23 @@
 <script setup lang="ts">
 	const route = useRoute('home-project-id-registry-registryId')
 	const registryId = route.params.registryId
+	const router = useRouter()
+	const navigateBackward = () => router.go(-1)
+
 	const { data: registry } = await useGetRegistryById(registryId)
 	useSeoMeta({ title: 'Ashou - View registry results' })
 </script>
 <template>
-	<section class="flex flex-col h-full min-h-screen place-items-center">
+	<main
+		class="flex flex-col justify-center w-full h-full max-w-4xl space-y-1 sm:min-h-screen"
+	>
+		<aside class="flex flex-row items-center p-5 mb-3 space-x-1">
+			<Icon
+				name="carbon:arrow-left"
+				class="duration-100 ease-in-out w-7 h-7 hover:cursor-pointer hover:opacity-70"
+				@click="navigateBackward"
+			/>
+		</aside>
 		<h2
 			class="pb-2 text-3xl font-semibold tracking-tight text-center transition-colors border-b scroll-m-20 first:mt-0"
 		>
@@ -34,5 +46,5 @@
 				<a href="https://web.dev/tags/performance/" class="underline">this out</a>
 			</UIParagraph>
 		</aside>
-	</section>
+	</main>
 </template>

--- a/src/pages/home/project/[id]/registry/[registryId].vue
+++ b/src/pages/home/project/[id]/registry/[registryId].vue
@@ -41,10 +41,10 @@
 			<RegistryResult label="Time to interactive" :metric="registry.ttiScore" />
 		</article>
 		<aside class="p-5 border-t-2 border-primary/5">
-			<UIParagraph class="text-center">
-				For more information about these metrics, you can check
+			<UiParagraph class="text-center">
+				For more information about web metrics, you can check
 				<a href="https://web.dev/tags/performance/" class="underline">this out</a>
-			</UIParagraph>
+			</UiParagraph>
 		</aside>
 	</main>
 </template>

--- a/src/pages/home/project/[id]/registry/[registryId].vue
+++ b/src/pages/home/project/[id]/registry/[registryId].vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+	const route = useRoute('home-project-id-registry-registryId')
+	const registryId = route.params.registryId
+	const { data: registry } = await useGetRegistryById(registryId)
+
+</script>
+<template>
+	<div>{{ JSON.stringify(registry) }}</div>
+</template>

--- a/src/pages/home/project/[id]/registry/[registryId].vue
+++ b/src/pages/home/project/[id]/registry/[registryId].vue
@@ -2,8 +2,37 @@
 	const route = useRoute('home-project-id-registry-registryId')
 	const registryId = route.params.registryId
 	const { data: registry } = await useGetRegistryById(registryId)
-
+	useSeoMeta({ title: 'Ashou - View registry results' })
 </script>
 <template>
-	<div>{{ JSON.stringify(registry) }}</div>
+	<section class="flex flex-col h-full min-h-screen place-items-center">
+		<h2
+			class="pb-2 text-3xl font-semibold tracking-tight text-center transition-colors border-b scroll-m-20 first:mt-0"
+		>
+			Registry results
+		</h2>
+		<article class="grid w-full h-full grid-cols-2" v-if="registry">
+			<RegistryResult
+				label="Largest contentful paint"
+				:metric="registry.lcpScore"
+			/>
+			<RegistryResult label="First contentful paint" :metric="registry.fcpScore" />
+			<RegistryResult
+				label="Cumulative layout shift"
+				:metric="registry.clsScore"
+			/>
+			<RegistryResult label="Speed index" :metric="registry.siScore" />
+			<RegistryResult
+				label="Total blocking time"
+				:metric="registry.blockingTimeScore"
+			/>
+			<RegistryResult label="Time to interactive" :metric="registry.ttiScore" />
+		</article>
+		<aside class="p-5 border-t-2 border-primary/5">
+			<UIParagraph class="text-center">
+				For more information about these metrics, you can check
+				<a href="https://web.dev/tags/performance/" class="underline">this out</a>
+			</UIParagraph>
+		</aside>
+	</section>
 </template>

--- a/src/pages/home/project/create.vue
+++ b/src/pages/home/project/create.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-	import { ProjectOutput, containsErrors, errorFromField } from '@/utils/valibot'
+	import {  containsErrors, errorFromField } from '@/utils/valibot'
 
-	useSeoMeta({ title: 'Ashou - Create new project' })
+	useSeoMeta({ title: 'Webmetrics - Create new project' })
 	const { create, formErrors, formFields, isLoading } = useCreateProject()
 </script>
 

--- a/src/pages/home/project/index.vue
+++ b/src/pages/home/project/index.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+
+useSeoMeta({title:"Webmetrics | Projects"})
+</script>
+<template>
+	<main
+		class="flex flex-col justify-center w-full h-full max-w-2xl space-y-3 sm:min-h-screen"
+	>
+		<h2
+			class="pb-2 mb-4 text-3xl font-semibold tracking-tight text-center transition-colors border-b scroll-m-20 first:mt-0"
+		>
+			Welcome to your project lists!
+		</h2>
+		<UiParagraph
+			>These projects can contain different registries based on Lighthouse
+			Auditories, where you can analyze each one of them, in order to fullfit a
+			full-time web performance scan.</UiParagraph
+		>
+		<UiParagraph class="text-center">
+			If you'd like to start creating a project.
+			<NuxtLink to="/home/project/create" class="underline"
+				>Click over here.</NuxtLink
+			>
+		</UiParagraph>
+	</main>
+</template>

--- a/src/pages/home/project/update/[id].vue
+++ b/src/pages/home/project/update/[id].vue
@@ -9,7 +9,7 @@
 		id,
 	})
 
-	useSeoMeta({ title: `Ashou - Update ${project.value?.existingProject?.name}` })
+	useSeoMeta({ title: `Webmetrics - Update ${project.value?.existingProject?.name}` })
 </script>
 <template>
 	<main class="container w-full h-screen max-w-4xl mx-auto mt-5">

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -2,7 +2,7 @@
 	definePageMeta({
 		auth: false,
 	})
-	useSeoMeta({ title: 'Bienvenid@ a Ashou!' })
+	useSeoMeta({ title: 'Welcome to Webmetrics!' })
 </script>
 
 <template>
@@ -11,7 +11,7 @@
 			<nav
 				class="container flex flex-row items-center justify-between max-w-2xl mx-auto"
 			>
-				<NuxtLink to="/">Ashou</NuxtLink>
+				<NuxtLink to="/">Webmetrics</NuxtLink>
 				<NuxtLink to="/login" class="underline opacity-60" >Sign in</NuxtLink>
 			</nav>
 		</header>
@@ -19,10 +19,10 @@
 			class="container flex flex-col justify-center h-screen max-w-4xl mx-auto space-y-2 text-center"
 		>
 			<h1 class="text-4xl font-extrabold tracking-tight scroll-m-20 lg:text-5xl">
-				Optimize <span class="text-sky-500">web metrics</span> with Ashou
+				Optimize <span class="text-sky-500">web metrics</span> with Webmetrics
 			</h1>
 			<UiParagraph class="opacity-90">
-				With Ashou, you can define a web page registry, that contains web page
+				With Webmetrics, you can define a web page registry, that contains web page
 				metrics, and then you can compare each registry.
 			</UiParagraph>
 			<NuxtLink

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -5,7 +5,7 @@
 			navigateAuthenticatedTo: '/home',
 		},
 	})
-	useSeoMeta({ title: 'Ashou - Sign in' })
+	useSeoMeta({ title: 'Webmetrics - Sign in' })
 	const { signIn } = useAuth()
 	const runtime = useRuntimeConfig()
 	const callbackUrl = runtime.app.baseURL + 'home'
@@ -19,14 +19,14 @@
 			<h2
 				class="text-4xl font-extrabold tracking-tight text-center scroll-m-20 lg:text-5xl"
 			>
-				Sign in to Ashou!
+				Sign in to Webmetrics!
 			</h2>
 			<UiParagraph class="text-center"
 				>You're close to organize your projects with its web metrics!</UiParagraph
 			>
 			<button
 				type="button"
-				title="Ingresar a Ashou desde Github"
+				title="Ingresar a Webmetrics desde Github"
 				class="inline-flex items-center self-center justify-center w-full p-3 space-x-1 text-sm font-medium transition-colors rounded-md shadow bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
 				@click="
 					signIn('github', {

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
-	definePageMeta({ auth: false })
+	definePageMeta({
+		auth: {
+			unauthenticatedOnly: true,
+			navigateAuthenticatedTo: '/home',
+		},
+	})
 	useSeoMeta({ title: 'Ashou - Sign in' })
 	const { signIn } = useAuth()
 	const runtime = useRuntimeConfig()

--- a/src/server/api/v1/project/[id]/registry/[registryId]/index.delete.ts
+++ b/src/server/api/v1/project/[id]/registry/[registryId]/index.delete.ts
@@ -10,7 +10,7 @@ export default defineEventHandler(async (ev) => {
 			throw createError({ statusCode: 400, statusMessage: 'Missing ID' })
 
 		const deletedProjectRegistry = await prisma.registry.delete({
-			where: { id: params.id },
+			where: { id: params.registryId },
 		})
 		return { deletedProjectRegistry }
 	} catch (e) {

--- a/src/server/api/v1/project/[id]/registry/[registryId]/index.get.ts
+++ b/src/server/api/v1/project/[id]/registry/[registryId]/index.get.ts
@@ -1,0 +1,18 @@
+import { registryById } from '@/server/models/registry.server'
+
+// This route returns registries based on the Project ID set on params.
+export default defineEventHandler(async (ev) => {
+	try {
+		const params = ev.context.params
+		if (!params)
+			throw createError({ statusCode: 400, statusMessage: 'Missing ID' })
+		const id = params.registryId
+		const existingRegistry = await registryById({
+			id,
+		})
+		return { existingRegistry }
+	} catch (e) {
+		if (e instanceof Error)
+			throw createError({ statusCode: 500, statusMessage: e.message })
+	}
+})

--- a/src/server/api/v1/project/[id]/registry/index.get.ts
+++ b/src/server/api/v1/project/[id]/registry/index.get.ts
@@ -1,0 +1,15 @@
+import { registriesByProjectId } from '@/server/models/registry.server'
+
+// This route returns registries based on the Project ID set on params.
+export default defineEventHandler(async (ev) => {
+	try {
+		const params = ev.context.params
+		if (!params)
+			throw createError({ statusCode: 400, statusMessage: 'Missing ID' })
+		const existingProject = await registriesByProjectId({ projectId: params.id })
+		return { existingProject }
+	} catch (e) {
+		if (e instanceof Error)
+			throw createError({ statusCode: 500, statusMessage: e.message })
+	}
+})

--- a/src/server/api/v1/project/[id]/registry/index.get.ts
+++ b/src/server/api/v1/project/[id]/registry/index.get.ts
@@ -6,8 +6,10 @@ export default defineEventHandler(async (ev) => {
 		const params = ev.context.params
 		if (!params)
 			throw createError({ statusCode: 400, statusMessage: 'Missing ID' })
-		const existingProject = await registriesByProjectId({ projectId: params.id })
-		return { existingProject }
+		const existingRegistries = await registriesByProjectId({
+			projectId: params.id,
+		})
+		return { existingRegistries }
 	} catch (e) {
 		if (e instanceof Error)
 			throw createError({ statusCode: 500, statusMessage: e.message })

--- a/src/server/api/v1/project/[id]/registry/index.post.ts
+++ b/src/server/api/v1/project/[id]/registry/index.post.ts
@@ -22,7 +22,7 @@ export default defineEventHandler(async (ev) => {
 		const projectRegistry = await prisma.registry.create({
 			data: {
 				...registryMetadata,
-				project: { connect: { id: params.projectId } },
+				project: { connect: { id: params.id } },
 			},
 		})
 		return { projectRegistry }

--- a/src/server/api/v1/project/[id]/registry/index.post.ts
+++ b/src/server/api/v1/project/[id]/registry/index.post.ts
@@ -25,6 +25,7 @@ export default defineEventHandler(async (ev) => {
 				project: { connect: { id: params.id } },
 			},
 		})
+		console.log(projectRegistry)
 		return { projectRegistry }
 	} catch (e) {
 		if (e instanceof Error) {

--- a/src/server/models/registry.server.ts
+++ b/src/server/models/registry.server.ts
@@ -8,6 +8,7 @@ export const registriesByProjectId = async ({
 	try {
 		const registries = await prisma.registry.findMany({
 			where: { project: { projectId } },
+			orderBy: { createdAt: 'desc' },
 		})
 		return registries
 	} catch (e) {

--- a/src/server/models/registry.server.ts
+++ b/src/server/models/registry.server.ts
@@ -7,7 +7,7 @@ export const registriesByProjectId = async ({
 }) => {
 	try {
 		const registries = await prisma.registry.findMany({
-			where: { project: { projectId } },
+			where: { project: { id: projectId } },
 			orderBy: { createdAt: 'desc' },
 		})
 		return registries
@@ -16,7 +16,17 @@ export const registriesByProjectId = async ({
 		}
 	}
 }
-
+export const registryById = async ({ id }: { id: string }) => {
+	try {
+		const existingRegistry = await prisma.registry.findMany({
+			where: { id },
+		})
+		return existingRegistry
+	} catch (e) {
+		if (e instanceof Error) {
+		}
+	}
+}
 export const createRegistry = async (
 	input: RegistryOutput & { projectId: string }
 ) => {

--- a/src/server/models/registry.server.ts
+++ b/src/server/models/registry.server.ts
@@ -1,6 +1,10 @@
 import { prisma } from '@/server/db/prisma'
 import { RegistryOutput } from '@/utils/valibot'
-export const registriesByProjectId = async (projectId: string) => {
+export const registriesByProjectId = async ({
+	projectId,
+}: {
+	projectId: string
+}) => {
 	try {
 		const registries = await prisma.registry.findMany({
 			where: { project: { projectId } },

--- a/src/server/models/registry.server.ts
+++ b/src/server/models/registry.server.ts
@@ -18,7 +18,7 @@ export const registriesByProjectId = async ({
 }
 export const registryById = async ({ id }: { id: string }) => {
 	try {
-		const existingRegistry = await prisma.registry.findMany({
+		const existingRegistry = await prisma.registry.findUnique({
 			where: { id },
 		})
 		return existingRegistry

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,7 @@ export interface BootupTime {
 	description: string
 	score: number | null
 	scoreDisplayMode: ScoreDisplayMode
-	displayValue?: string
+	displayValue: string
 	details?: BootupTimeDetails
 	numericValue: number
 	numericUnit: NumericUnit
@@ -266,7 +266,7 @@ export interface CumulativeLayoutShift {
 	description: string
 	score: number | null
 	scoreDisplayMode: ScoreDisplayMode
-	displayValue?: string
+	displayValue: string
 	details?: CumulativeLayoutShiftDetails
 	numericValue?: number
 	numericUnit?: string
@@ -483,7 +483,7 @@ export interface DuplicatedJavascript {
 	numericValue: number
 	numericUnit: NumericUnit
 	warnings?: any[]
-	displayValue?: string
+	displayValue: string
 }
 
 export interface DuplicatedJavascriptDetails {
@@ -528,7 +528,7 @@ export interface FontDisplay {
 	scoreDisplayMode: string
 	details?: FontDisplayDetails
 	warnings?: any[]
-	displayValue?: string
+	displayValue: string
 }
 
 export interface FontDisplayDetails {

--- a/src/utils/parse-date.ts
+++ b/src/utils/parse-date.ts
@@ -1,0 +1,7 @@
+export const retrieveDateOnISOFormat = (date: Date) => {
+	const dateYear = date.getFullYear()
+	const dateMonth = (date.getMonth() + 1).toString().padStart(2, '0')
+	const dateDay = date.getDate().toString().padStart(2, '0')
+	const parsedFormatDate = `${dateYear}-${dateMonth}-${dateDay}`
+	return parsedFormatDate
+}

--- a/src/utils/valibot.ts
+++ b/src/utils/valibot.ts
@@ -14,12 +14,12 @@ export const createProjectSchema = object({
 	siteUrl: string([url('Invalid site URL')]),
 })
 export const registrySchema = object({
-	lcpScore: optional(string()),
-	fcpScore: optional(string()),
-	ttiScore: optional(string()),
-	blockingTimeScore: optional(string()),
-	siScore: optional(string()),
-	clsScore: optional(string()),
+	lcpScore: string(),
+	fcpScore: string(),
+	ttiScore: string(),
+	blockingTimeScore: string(),
+	siScore: string(),
+	clsScore: string(),
 })
 
 export type ProjectOutput = Output<typeof createProjectSchema>


### PR DESCRIPTION
## Description
This PR defines View registry history page, that displays its related to each project in a decremental order, and visualize its results. 

## Commits
- chore: add GET registries endpoint
- fix: update registry types & validation
- fix update registry query result variable name
- fix: sort registries by descending createdAt date field
- feat: add getRegistriesByProjectId conposable
- fix: replaced params.projectId with expected params.id
- fix: rename id param to registryId in order to avoid param colission while implementing dynamic fetching
- fix: return a unique registry on registryById func
- fix: rename fetch response type on getRegistryById in order to synchronize with the defined type on  Registry GET API Route
- fix: redirect if user's already logged in
- feat: add dark mode support
- feat: add registry server components
- chore: add result icon
- chore: add result item component
- fix: update styles in order to align with dark mode
- feat: add retrieveDateOnISOFormat to parse and display registry dates on cards
- feat: add dynamic registry results
- feat: add return back icon
- chore: add vueuse module
- chore: add vueuse dep
- feat: add theme switcher in order to enhance to support 100% dark mode
- chore: remove undefined feats on this branch
- feat: add theme-switch on home header
- feat: display empty registry component if there's no registry defined on project
- fix: registry item styles
- fix: UiParagraph import
- chore: set audit strategy as mobile only
- feat: add useMetricStatus composable in order to parse & compare metric results
- replace previous metrics comparing method w/ useMetricStatus composable
- feat: add project home page
- feat: update routes title
- fix: update dynamic registry page title
- fix: update login title & heading referring to Ashou
